### PR TITLE
feat(producer): use `message.timeout.ms` instead of cancellation token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-﻿## [0.6.0](https://github.com/jonathansant/orleans.streams.kafka/compare/0.4.0...0.6.0) (2018-11-19)
+﻿## [0.6.2](https://github.com/jonathansant/orleans.streams.kafka/compare/0.6.0...0.6.2) (2018-11-22)
+
+### Features
+
+- removed `timeout` from the `Produce` extensions method. Producer timeout is now set via the `message.timeout.ms` Producer config.
+
+## [0.6.0](https://github.com/jonathansant/orleans.streams.kafka/compare/0.4.0...0.6.0) (2018-11-19)
 
 ### Features
 

--- a/Orleans.Streams.Kafka/Config/KafkaStreamOptionsExtensions.cs
+++ b/Orleans.Streams.Kafka/Config/KafkaStreamOptionsExtensions.cs
@@ -1,14 +1,18 @@
-﻿using System;
-using Orleans.Streams.Kafka.Utils;
+﻿using Orleans.Streams.Kafka.Utils;
 using System.Collections.Generic;
-using System.IO;
+using System.Globalization;
 
 namespace Orleans.Streams.Kafka.Config
 {
 	internal static class KafkaStreamOptionsExtensions
 	{
 		public static IDictionary<string, string> ToProducerProperties(this KafkaStreamOptions options)
-			=> CreateCommonProperties(options);
+		{
+			var config =  CreateCommonProperties(options);
+			config.TryAdd("message.timeout.ms", options.ProducerTimeout.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
+
+			return config;
+		}
 
 		public static IDictionary<string, string> ToConsumerProperties(this KafkaStreamOptions options)
 		{

--- a/Orleans.Streams.Kafka/Core/KafkaAdapter.cs
+++ b/Orleans.Streams.Kafka/Core/KafkaAdapter.cs
@@ -64,7 +64,7 @@ namespace Orleans.Streams.Kafka.Core
 					false
 				);
 
-				await _producer.Produce(batch, _options.ProducerTimeout);
+				await _producer.Produce(batch);
 			}
 			catch (Exception ex)
 			{

--- a/Orleans.Streams.Kafka/Producer/ProducerExtensions.cs
+++ b/Orleans.Streams.Kafka/Producer/ProducerExtensions.cs
@@ -1,28 +1,21 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Confluent.Kafka;
+﻿using Confluent.Kafka;
 using Orleans.Streams.Kafka.Core;
+using System;
+using System.Threading.Tasks;
 
 namespace Orleans.Streams.Kafka.Producer
 {
 	public static class ProducerExtensions
 	{
-		public static async Task Produce(this Producer<byte[], KafkaBatchContainer> producer, KafkaBatchContainer batch, TimeSpan timeout)
-		{
-			using (var tokenSource = new CancellationTokenSource(timeout))
-			{
-				await producer.ProduceAsync(
-							batch.StreamNamespace,
-							new Message<byte[], KafkaBatchContainer>
-							{
-								Key = batch.StreamGuid.ToByteArray(),
-								Value = batch,
-								Timestamp = new Timestamp(DateTimeOffset.UtcNow)
-							}, 
-						tokenSource.Token
-					);
-			}
-		}
+		public static Task Produce(this Producer<byte[], KafkaBatchContainer> producer, KafkaBatchContainer batch)
+			=> producer.ProduceAsync(
+				batch.StreamNamespace,
+				new Message<byte[], KafkaBatchContainer>
+				{
+					Key = batch.StreamGuid.ToByteArray(),
+					Value = batch,
+					Timestamp = new Timestamp(DateTimeOffset.UtcNow)
+				}
+			);
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orleans.streams.kafka",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Orleans Kafka Stream Provider",
   "solution": "Orleans.Streams.Kafka-build.sln",
   "dependencies": {},


### PR DESCRIPTION
Perf improvement as per: https://github.com/jonathansant/Orleans.Streams.Kafka/issues/2