### PR TITLE
feat(message tracking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-﻿## [0.6.4](https://github.com/jonathansant/orleans.streams.kafka/compare/0.6.3...0.6.4) (2019-01-19)
+﻿## [0.7.0](https://github.com/jonathansant/orleans.streams.kafka/compare/0.6.4...0.7.0) (2019-01-20)
+
+### Features
+
+- `KafkaAdapterReceiver` now can track a message using the new `MessageTrackerAPI` see: [`UseLoggingTracker`](www.gooogle.com). 
+
+### BREAKING CHANGES
+
+ - `Orleans`
+	- updated to orleans 2.2.3.
+
+## [0.6.4](https://github.com/jonathansant/orleans.streams.kafka/compare/0.6.3...0.6.4) (2019-01-19)
 
 ### Bug Fixes
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,6 +26,6 @@
 
   <!-- Shared Package Versions -->
   <PropertyGroup>
-    <StreamUtilsVersion>2.*</StreamUtilsVersion>
+    <StreamUtilsVersion>3.*</StreamUtilsVersion>
   </PropertyGroup>
 </Project>

--- a/Orleans.Streams.Kafka.E2E/Orleans.Streams.Kafka.E2E.csproj
+++ b/Orleans.Streams.Kafka.E2E/Orleans.Streams.Kafka.E2E.csproj
@@ -18,13 +18,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Microsoft.Orleans.Core" Version="2.1.2" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.1.2">
+    <PackageReference Include="Microsoft.Orleans.Core" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.1.2" />
-    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.2.3" />
+    <PackageReference Include="Microsoft.Orleans.TestingHost" Version="2.2.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/Orleans.Streams.Kafka.E2E/Tests/TestBase.cs
+++ b/Orleans.Streams.Kafka.E2E/Tests/TestBase.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using Orleans.Streams.Utils.MessageTracking;
 using Xunit;
 
 namespace Orleans.Streams.Kafka.E2E.Tests
@@ -51,7 +52,7 @@ namespace Orleans.Streams.Kafka.E2E.Tests
 				.AddKafkaStreamProvider(Consts.KafkaStreamProvider, options =>
 				{
 					options.BrokerList = new List<string> { "localhost:9092" };
-					options.ConsumerGroupId = "TestGroup";
+					options.ConsumerGroupId = "E2EGroup";
 					options.Topics = new List<string> { Consts.StreamNamespace, Consts.StreamNamespace2 };
 					options.PollTimeout = TimeSpan.FromMilliseconds(10);
 					options.ExternalMessageIdentifier = "x-external-message";
@@ -65,14 +66,16 @@ namespace Orleans.Streams.Kafka.E2E.Tests
 		public void Configure(ISiloHostBuilder hostBuilder)
 			=> hostBuilder
 				.AddMemoryGrainStorage("PubSubStore")
+				.UseLoggingTracker()
 				.AddKafkaStreamProvider(Consts.KafkaStreamProvider, options =>
 				{
 					options.BrokerList = new List<string> { "localhost:9092" };
-					options.ConsumerGroupId = "TestGroup";
+					options.ConsumerGroupId = "E2EGroup";
 					options.ExternalMessageIdentifier = "x-external-message";
 					options.ConsumeMode = ConsumeMode.StreamEnd;
 					options.Topics = new List<string> { Consts.StreamNamespace, Consts.StreamNamespace2 };
 					options.PollTimeout = TimeSpan.FromMilliseconds(10);
+					options.MessageTrackingEnabled = true;
 				})
 				.ConfigureApplicationParts(parts =>
 					parts.AddApplicationPart(typeof(RoundTripGrain).Assembly).WithReferences());

--- a/Orleans.Streams.Kafka/Config/KafkaStreamOptions.cs
+++ b/Orleans.Streams.Kafka/Config/KafkaStreamOptions.cs
@@ -22,6 +22,7 @@ namespace Orleans.Streams.Kafka.Config
 		public string SaslPassword { get; set; }
 		public string SaslMechanisms { get; set; }
 		public TimeSpan PollBufferTimeout { get; set; } = TimeSpan.FromMilliseconds(500);
+		public bool MessageTrackingEnabled { get; set; }
 	}
 
 	public class Credentials

--- a/Orleans.Streams.Kafka/Core/KafkaAdapter.cs
+++ b/Orleans.Streams.Kafka/Core/KafkaAdapter.cs
@@ -17,6 +17,7 @@ namespace Orleans.Streams.Kafka.Core
 		private readonly IDictionary<string, QueueProperties> _queueProperties;
 		private readonly SerializationManager _serializationManager;
 		private readonly ILoggerFactory _loggerFactory;
+		private readonly IGrainFactory _grainFactory;
 		private readonly Producer<byte[], KafkaBatchContainer> _producer;
 		private readonly ILogger<KafkaAdapter> _logger;
 
@@ -29,13 +30,15 @@ namespace Orleans.Streams.Kafka.Core
 			KafkaStreamOptions options,
 			IDictionary<string, QueueProperties> queueProperties,
 			SerializationManager serializationManager,
-			ILoggerFactory loggerFactory
+			ILoggerFactory loggerFactory,
+			IGrainFactory grainFactory
 		)
 		{
 			_options = options;
 			_queueProperties = queueProperties;
 			_serializationManager = serializationManager;
 			_loggerFactory = loggerFactory;
+			_grainFactory = grainFactory;
 			_logger = _loggerFactory.CreateLogger<KafkaAdapter>();
 
 			Name = providerName;
@@ -68,7 +71,12 @@ namespace Orleans.Streams.Kafka.Core
 			}
 			catch (Exception ex)
 			{
-				_logger.LogError(ex, "Failed to publish message: streamNamespace: {namespace}, streamGuid: {guid}", streamNamespace, streamGuid);
+				_logger.LogError(
+					ex, "Failed to publish message: streamNamespace: {namespace}, streamGuid: {guid}", 
+					streamNamespace, 
+					streamGuid.ToString()
+				);
+				
 				throw;
 			}
 		}
@@ -78,7 +86,8 @@ namespace Orleans.Streams.Kafka.Core
 				_queueProperties[queueId.GetStringNamePrefix()], 
 				_options, 
 				_serializationManager, 
-				_loggerFactory
+				_loggerFactory,
+				_grainFactory
 			);
 
 		public void Dispose()

--- a/Orleans.Streams.Kafka/Core/KafkaAdapterFactory.cs
+++ b/Orleans.Streams.Kafka/Core/KafkaAdapterFactory.cs
@@ -19,6 +19,7 @@ namespace Orleans.Streams.Kafka.Core
 		private readonly KafkaStreamOptions _options;
 		private readonly SerializationManager _serializationManager;
 		private readonly ILoggerFactory _loggerFactory;
+		private readonly IGrainFactory _grainFactory;
 		private readonly IQueueAdapterCache _adapterCache;
 		private readonly IStreamQueueMapper _streamQueueMapper;
 		private readonly ILogger<KafkaAdapterFactory> _logger;
@@ -29,7 +30,8 @@ namespace Orleans.Streams.Kafka.Core
 			KafkaStreamOptions options,
 			SimpleQueueCacheOptions cacheOptions,
 			SerializationManager serializationManager,
-			ILoggerFactory loggerFactory
+			ILoggerFactory loggerFactory,
+			IGrainFactory grainFactory
 		)
 		{
 			_options = options ?? throw new ArgumentNullException(nameof(options));
@@ -37,6 +39,7 @@ namespace Orleans.Streams.Kafka.Core
 			_name = name;
 			_serializationManager = serializationManager;
 			_loggerFactory = loggerFactory;
+			_grainFactory = grainFactory;
 			_logger = loggerFactory.CreateLogger<KafkaAdapterFactory>();
 
 			if (options.Topics != null && options.Topics.Count == 0)
@@ -59,7 +62,8 @@ namespace Orleans.Streams.Kafka.Core
 				_options,
 				_queueProperties,
 				_serializationManager,
-				_loggerFactory
+				_loggerFactory,
+				_grainFactory
 			);
 
 			return Task.FromResult<IQueueAdapter>(adapter);

--- a/Orleans.Streams.Kafka/Orleans.Streams.Kafka.csproj
+++ b/Orleans.Streams.Kafka/Orleans.Streams.Kafka.csproj
@@ -7,8 +7,8 @@
   <!-- vendor packages -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.1.2" />
-    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="2.2.3" />
     <PackageReference Include="Confluent.Kafka" Version="1.0.0-beta2" />
   </ItemGroup>
   <!-- packages -->

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Kafka persistent stream provider for Microsoft Orleans that uses the [Confluent 
 # Dependencies
 `Orleans.Streams.Kafka` has the following dependencies:
 * Confluent.Kafka: **1.0.0-beta-2**
-* Orleans.Streams.Utils: **2.1.0**
+* Orleans.Streams.Utils: [![NuGet version](https://badge.fury.io/nu/Orleans.Streams.Utils.svg)](https://badge.fury.io/nu/Orleans.Streams.Utils)
 
 ## Installation
 To start working with the `Orleans.Streams.Kafka` make sure you do the following steps:

--- a/Samples/ConfluentSample/ConfluentSample.csproj
+++ b/Samples/ConfluentSample/ConfluentSample.csproj
@@ -8,6 +8,6 @@
     <PackageReference Include="Confluent.Kafka" Version="1.0.0-beta2" />
     <PackageReference Include="librdkafka.redist.osx-x64" Version="0.11.1-TEST4" />
     <PackageReference Include="librdkafka.redist.win-x64" Version="0.11.1-TEST4" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/Samples/TestClient/TestClient.csproj
+++ b/Samples/TestClient/TestClient.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Confluent.Kafka" Version="1.0.0-beta2" />
     <PackageReference Include="librdkafka.redist.win-x64" Version="0.11.1-TEST4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Orleans.Client" Version="2.1.2" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Client" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/TestGrains/TestGrains.csproj
+++ b/Samples/TestGrains/TestGrains.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="1.0.0-beta2" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.1.2" />
-    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.1.2">
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Orleans.OrleansCodeGenerator.Build" Version="2.2.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Samples/TestSilo/Program.cs
+++ b/Samples/TestSilo/Program.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Streams.Utils.MessageTracking;
 
 namespace TestSilo
 {
@@ -33,12 +35,14 @@ namespace TestSilo
 				.ConfigureLogging(logging => logging.AddConsole())
 				.AddMemoryGrainStorageAsDefault()
 				.AddMemoryGrainStorage("PubSubStore")
+				.UseLoggingTracker()
 				.AddKafkaStreamProvider("KafkaProvider", options =>
 				{
 					options.BrokerList = new List<string> { "localhost:9092" };
 					options.ConsumerGroupId = "TestGroup";
 					options.ExternalMessageIdentifier = "external";
 					options.Topics = new List<string> { "gossip-testing" };
+					options.MessageTrackingEnabled = true;
 				});
 
 			var host = builder.Build();

--- a/Samples/TestSilo/TestSilo.csproj
+++ b/Samples/TestSilo/TestSilo.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="Confluent.Kafka" Version="1.0.0-beta2" />
     <PackageReference Include="librdkafka.redist.win-x64" Version="0.11.1-TEST4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.1.2" />
-    <PackageReference Include="Microsoft.Orleans.Server" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Orleans.Server" Version="2.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orleans.streams.kafka",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "description": "Orleans Kafka Stream Provider",
   "solution": "Orleans.Streams.Kafka-build.sln",
   "dependencies": {},


### PR DESCRIPTION
* `KafkaAdapterReceiver` now can track a message using the new `MessageTrackerAPI`
* updated to Orleans 2.2.3
* bump `Orleans.Streams.Utils to 3.*`