### PR TITLE
Updated Confluent packages to stable release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,7 +27,7 @@
   <!-- Shared Package Versions -->
   <PropertyGroup>
     <StreamUtilsVersion>9.0.0-dev-66</StreamUtilsVersion>
-    <ConfluentKafkaVersion>1.3.0-PRE1</ConfluentKafkaVersion>
+    <ConfluentKafkaVersion>1.4.0</ConfluentKafkaVersion>
     <OrleansVersion>3.0.0</OrleansVersion>
     <MicrosoftLoggingVersion>3.0.0</MicrosoftLoggingVersion>
   </PropertyGroup>

--- a/Orleans.Streams.Kafka.E2E/Tests/AvroDeserilizationTests.cs
+++ b/Orleans.Streams.Kafka.E2E/Tests/AvroDeserilizationTests.cs
@@ -48,7 +48,7 @@ namespace Orleans.Streams.Kafka.E2E.Tests
 
 			using (var schema = new CachedSchemaRegistryClient(new SchemaRegistryConfig
 			{
-				SchemaRegistryUrl = "https://[host name]/schema-registry"
+				Url = "https://[host name]/schema-registry"
 			}))
 			using (var producer = new ProducerBuilder<byte[], TestModelAvro>(config)
 				.SetValueSerializer(new AvroSerializer<TestModelAvro>(schema).AsSyncOverAsync())

--- a/Orleans.Streams.Kafka/Orleans.Streams.Kafka.csproj
+++ b/Orleans.Streams.Kafka/Orleans.Streams.Kafka.csproj
@@ -7,11 +7,12 @@
   </PropertyGroup>
   <!-- vendor packages -->
   <ItemGroup>
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.3.0-PRE1" />
+    <PackageReference Include="Confluent.Kafka" Version="$(ConfluentKafkaVersion)" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="$(ConfluentKafkaVersion)" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="$(ConfluentKafkaVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftLoggingVersion)" />
     <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="$(OrleansVersion)" />
     <PackageReference Include="Microsoft.Orleans.OrleansProviders" Version="$(OrleansVersion)" />
-    <PackageReference Include="Confluent.Kafka" Version="$(ConfluentKafkaVersion)" />
     <!-- <ProjectReference Include="..\..\confluent-kafka-dotnet-jonny\src\Confluent.SchemaRegistry.Serdes\Confluent.SchemaRegistry.Serdes.csproj" /> -->
   </ItemGroup>
   <!-- packages -->

--- a/Orleans.Streams.Kafka/Orleans.Streams.Kafka.csproj
+++ b/Orleans.Streams.Kafka/Orleans.Streams.Kafka.csproj
@@ -8,7 +8,6 @@
   <!-- vendor packages -->
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="$(ConfluentKafkaVersion)" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="$(ConfluentKafkaVersion)" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="$(ConfluentKafkaVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftLoggingVersion)" />
     <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="$(OrleansVersion)" />

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Kafka persistent stream provider for Microsoft Orleans that uses the [Confluent 
 
 # Dependencies
 `Orleans.Streams.Kafka` has the following dependencies:
-* Confluent.Kafka: **1.1.0**
+* Confluent.Kafka: **1.4.0**
 * Orleans.Streams.Utils: [![NuGet version](https://badge.fury.io/nu/Orleans.Streams.Utils.svg)](https://badge.fury.io/nu/Orleans.Streams.Utils)
 
 ## Installation

--- a/Samples/ConfluentSample/ConfluentSample.csproj
+++ b/Samples/ConfluentSample/ConfluentSample.csproj
@@ -5,9 +5,9 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Confluent.Apache.Avro" Version="1.7.7.7" />
     <PackageReference Include="Confluent.Kafka" Version="$(ConfluentKafkaVersion)" />
-    <PackageReference Include="Confluent.SchemaRegistry.Serdes" Version="1.3.0-PRE1" />
+    <PackageReference Include="Confluent.SchemaRegistry" Version="$(ConfluentKafkaVersion)" />
+    <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="$(ConfluentKafkaVersion)" />
     <!-- <ProjectReference Include="..\..\..\confluent-kafka-dotnet-jonny\src\Confluent.SchemaRegistry.Serdes\Confluent.SchemaRegistry.Serdes.csproj" /> -->
     <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="$(MicrosoftLoggingVersion)" />
   </ItemGroup>

--- a/Samples/ConfluentSample/ConfluentSample.csproj
+++ b/Samples/ConfluentSample/ConfluentSample.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="$(ConfluentKafkaVersion)" />
-    <PackageReference Include="Confluent.SchemaRegistry" Version="$(ConfluentKafkaVersion)" />
     <PackageReference Include="Confluent.SchemaRegistry.Serdes.Avro" Version="$(ConfluentKafkaVersion)" />
     <!-- <ProjectReference Include="..\..\..\confluent-kafka-dotnet-jonny\src\Confluent.SchemaRegistry.Serdes\Confluent.SchemaRegistry.Serdes.csproj" /> -->
     <PackageReference Include="Microsoft.Orleans.Core.Abstractions" Version="$(MicrosoftLoggingVersion)" />

--- a/Samples/ConfluentSample/Program.cs
+++ b/Samples/ConfluentSample/Program.cs
@@ -38,7 +38,7 @@ namespace ConfluentSample
 			{
 				var r = new Random();
 
-				using (var schema = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = RegistryUrl }))
+				using (var schema = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = RegistryUrl }))
 				using (var producer = new ProducerBuilder<byte[], AMessage>(new ProducerConfig
 				{
 					BootstrapServers = string.Join(',', Brokers)
@@ -72,7 +72,7 @@ namespace ConfluentSample
 				GroupId = "jonny-king-better-than-michael",
 			};
 
-			using (var schema = new CachedSchemaRegistryClient(new SchemaRegistryConfig { SchemaRegistryUrl = RegistryUrl }))
+			using (var schema = new CachedSchemaRegistryClient(new SchemaRegistryConfig { Url = RegistryUrl }))
 			using (var consumer = new ConsumerBuilder<string, AMessage>(conf).SetValueDeserializer(new AvroDeserializer<AMessage>(schema).AsSyncOverAsync()).Build())
 			using (var admin = new AdminClientBuilder(conf).Build())
 			{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orleans.streams.kafka",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Orleans Kafka Stream Provider",
   "solution": "Orleans.Streams.Kafka-build.sln",
   "dependencies": {},


### PR DESCRIPTION
* Updated from 1.4.0 RC1 to stable release
* Updated older Confluent packages to use `ConfluentKafkaVersion` property