### PR TITLE
Don't assume the number of bytes required

### DIFF
--- a/Orleans.Streams.Kafka/Serialization/KafkaBatchContainerSerializer.cs
+++ b/Orleans.Streams.Kafka/Serialization/KafkaBatchContainerSerializer.cs
@@ -17,8 +17,7 @@ namespace Orleans.Streams.Kafka.Serialization
 		public byte[] Serialize(KafkaBatchContainer data, Confluent.Kafka.SerializationContext context)
 		{
 			var serializedString = _serializer.Serialize(data, typeof(KafkaBatchContainer));
-			var bytes = new byte[serializedString.Length];
-			Encoding.UTF8.GetBytes(serializedString, bytes);
+			var bytes = Encoding.UTF8.GetBytes(serializedString);
 			return bytes;
 		}
 	}


### PR DESCRIPTION
Serialization would fail when the number of required bytes to encode in UTF8 is larger than the number of bytes used by UTF16.